### PR TITLE
fix(gm): fix a case where user wouldn't be notified of a gm crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ See [`gulp-cordova`](https://github.com/SamVerschueren/gulp-cordova) for the ful
 ## Contributors
 
 - Sam Verschueren [<sam.verschueren@gmail.com>]
+- Vincent Vieira [<vincent.vieira@supinfo.com>]
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ When the project is build for a platform, the icon provided will be used as appl
 
 ## API
 
-### icon(file)
+### icon(file, options)
 
 #### file
 
@@ -40,6 +40,20 @@ When the project is build for a platform, the icon provided will be used as appl
 Type: `string`
 
 The path to the `png` or `svg` icon that will be used as application icon.
+
+#### options
+*Optional*
+Type: `object`
+
+##### errorHandlingStrategy
+*Optional*
+Type: `string`
+Defaults to : `lenient`
+
+The error handling strategy of the process. This field has 3 possible values:
+* `lenient`, the default one : any encountered error is silently discarded and the build continues
+* `warn` : any encountered error is logged as a warning on the console
+* `throw` : any encountered error is thrown and interrupts the Gulp stream
 
 ## Related
 

--- a/hooks/before_prepare/icon.ejs
+++ b/hooks/before_prepare/icon.ejs
@@ -22,14 +22,11 @@ var platforms = require('../platforms.json'),
     platform = platforms[process.env.CORDOVA_PLATFORMS];
 
 if(!platform) {
-    var errorMessage = "Cordova platform variable has not been found, cannot generate any icons without this value";
     // Exit if the platform could not be found
     <% if (errorHandlingStrategy === "lenient") { %>
-        return 0;
-    <% } else if(errorHandlingStrategy === "warn") { %>
-        console.warn(errorMessage);
-    <% } else if(errorHandlingStrategy === "throw") { %>
-        throw new Error(errorMessage);
+    return 0;
+    <% } else { %>
+    throw new Error("Cordova platform variable has not been found, cannot generate any icons without this value");
     <% } %>
 }
 
@@ -177,9 +174,9 @@ function generate(done) {
 return generate(function(error) {
     if(error){
         <% if(errorHandlingStrategy === "warn") { %>
-            console.warn(error);
+        console.warn(error.message);
         <% } else if(errorHandlingStrategy === "throw") { %>
-            throw new Error(error);
+        throw error;
         <% } %>
     }
     return 0;

--- a/hooks/before_prepare/icon.js
+++ b/hooks/before_prepare/icon.js
@@ -151,15 +151,7 @@ function generate(done) {
                 mkdirp.sync(path.dirname(dest));
             }
 
-            gm(source).density(icon.dimension, icon.dimension).write(dest, function(err){
-                if(!err){
-                    next();
-                }
-                else {
-                    throw err;
-                }
-            });
-
+            gm(source).density(icon.dimension, icon.dimension).write(dest, next);
         }, function(err) {
             if(err) {
                 return done(err);

--- a/hooks/before_prepare/icon.js
+++ b/hooks/before_prepare/icon.js
@@ -138,12 +138,12 @@ function generate(done) {
         
         // Default, the icon is a PNG image
         var source = path.join(__dirname, '../../res/icon.png');
-            
+
         if(!fs.existsSync(source)) {
             // If the PNG image does not exist, it means it is an SVG image
-            source = path.join(__dirname, '../../res/icon.svg');;
+            source = path.join(__dirname, '../../res/icon.svg');
         }
-        
+
         async.each(platform.icons, function(icon, next) {
             var dest = path.join(root, icon.file);
 
@@ -151,7 +151,15 @@ function generate(done) {
                 mkdirp.sync(path.dirname(dest));
             }
 
-            gm(source).density(icon.dimension, icon.dimension).write(dest, next);
+            gm(source).density(icon.dimension, icon.dimension).write(dest, function(err){
+                if(!err){
+                    next();
+                }
+                else {
+                    throw err;
+                }
+            });
+
         }, function(err) {
             if(err) {
                 return done(err);

--- a/hooks/before_prepare/icon.js
+++ b/hooks/before_prepare/icon.js
@@ -22,8 +22,15 @@ var platforms = require('../platforms.json'),
     platform = platforms[process.env.CORDOVA_PLATFORMS];
 
 if(!platform) {
+    var errorMessage = "Cordova platform variable has not been found, cannot generate any icons without this value";
     // Exit if the platform could not be found
-    return 0;
+    <% if (errorHandlingStrategy === "lenient") { %>
+        return 0;
+    <% } else if(errorHandlingStrategy === "warn") { %>
+        console.warn(errorMessage);
+    <% } else if(errorHandlingStrategy === "throw") { %>
+        throw new Error(errorMessage);
+    <% } %>
 }
 
 /**
@@ -167,7 +174,13 @@ function generate(done) {
 }
 
 // Start generating
-return generate(function() {
-    // Just exit, regarding of what happened
+return generate(function(error) {
+    if(error){
+        <% if(errorHandlingStrategy === "warn") { %>
+            console.warn(error);
+        <% } else if(errorHandlingStrategy === "throw") { %>
+            throw new Error(error);
+        <% } %>
+    }
     return 0;
 });

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ var platforms = require('./platforms.json'),
 // export the module
 module.exports = function(src, options) {
     options = options || {};
-    options.errorHandlingStrategy = options.errorHandlingStrategy && errorHandlingStrategies.indexOf(options.errorHandlingStrategy) != -1 || "lenient";
+    options.errorHandlingStrategy = errorHandlingStrategies.indexOf(options.errorHandlingStrategy) != -1 && options.errorHandlingStrategy || "lenient";
 
     // Determine the type of the image provided
     var mimetype = mime.lookup(src),
@@ -87,6 +87,12 @@ module.exports = function(src, options) {
 
                 fs.readdirSync(hookPath).forEach(function(script) {
                     var scriptPath = path.join(hookPath, script);
+                    //Rename .ejs files to be .js files, after they had been interpolated.
+                    if(path.extname(scriptPath) === ".ejs"){
+                        var newScriptPath = path.join(path.dirname(scriptPath), path.basename(scriptPath, path.extname(scriptPath))+".js");
+                        fs.renameSync(scriptPath, newScriptPath);
+                        scriptPath = newScriptPath;
+                    }
                     fs.chmodSync(scriptPath, '755');
                 });
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-cordova-icon",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Add an icon to your cordova project.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-util": "^3.0.4",
     "image-size": "^0.3.5",
     "lodash": "^3.8.0",
+    "mem-fs": "^1.1.0",
     "mem-fs-editor": "^2.0.4",
     "mime-types": "^2.0.11",
     "mkdirp": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-util": "^3.0.4",
     "image-size": "^0.3.5",
     "lodash": "^3.8.0",
+    "mem-fs-editor": "^2.0.4",
     "mime-types": "^2.0.11",
     "mkdirp": "^0.5.0",
     "npmi": "^1.0.1",


### PR DESCRIPTION
Hey there,

I'm using your plugin in a professional project and I found out that if I didn't install ImageMagick first, the gulp task would crash without notifying me. Which is, in my opinion, kinda silly as exporting icons are pretty important in the build workflow, even more if you delete the original resources each time you build (as I do).

Tell me if there's any better way to handle errors, this is kind of a trivial commit.
I tested it without any issues.
Keep up the great work on these plugins !
