### PR TITLE
added option to use ImageMagick

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ Type: `object`
 ##### errorHandlingStrategy
 
 Type: `string`  
-Defaults to : `lenient`
+Default: `lenient`
 
 The error handling strategy of the process. This field has 3 possible values:
 * `lenient` (default): any encountered error is silently discarded and the build continues
 * `warn`: any encountered error is logged as a warning on the console
 * `throw`: any encountered error is thrown and interrupts the Gulp stream
 
-##### useImageMagick
+##### imageMagick
 
 Type: `boolean`  
-Defaults to : `false`
+Default: `false`
 
-Make use of ImageMagick instead of GraphicsMagick by default.
+Use ImageMagick instead of GraphicsMagick.
 
 ## Related
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ The error handling strategy of the process. This field has 3 possible values:
 * `warn`: any encountered error is logged as a warning on the console
 * `throw`: any encountered error is thrown and interrupts the Gulp stream
 
+##### useImageMagick
+
+Type: `boolean`  
+Defaults to : `false`
+
+Make use of ImageMagick instead of GraphicsMagick by default.
+
 ## Related
 
 See [`gulp-cordova`](https://github.com/SamVerschueren/gulp-cordova) for the full list of available packages.

--- a/hooks/before_prepare/icon.js
+++ b/hooks/before_prepare/icon.js
@@ -2,7 +2,7 @@
 'use strict';
 var path = require('path');
 var fs = require('fs');
-<% if(locals.imageMagick) { %>
+<% if (locals.imageMagick) { %>
 var gm = require('gm').subClass({imageMagick: true});
 <% } else { %>
 var gm = require('gm');

--- a/hooks/before_prepare/icon.js
+++ b/hooks/before_prepare/icon.js
@@ -2,7 +2,11 @@
 'use strict';
 var path = require('path');
 var fs = require('fs');
+<% if(useImageMagick) { %>
+var gm = require('gm').subClass({imageMagick: true});
+<% } else { %>
 var gm = require('gm');
+<% } %>
 var pify = require('pify');
 var Promise = require('pinkie-promise');
 var mkdirp = require('mkdirp');
@@ -144,6 +148,7 @@ Promise.resolve()
 		<% if(errorHandlingStrategy === 'warn') { %>
 		console.warn(err.message);
 		<% } else if(errorHandlingStrategy === 'throw') { %>
+		console.error(err.message);
 		throw err;
 		<% } %>
 	});

--- a/hooks/before_prepare/icon.js
+++ b/hooks/before_prepare/icon.js
@@ -2,7 +2,7 @@
 'use strict';
 var path = require('path');
 var fs = require('fs');
-<% if(useImageMagick) { %>
+<% if(locals.imageMagick) { %>
 var gm = require('gm').subClass({imageMagick: true});
 <% } else { %>
 var gm = require('gm');
@@ -148,7 +148,6 @@ Promise.resolve()
 		<% if(errorHandlingStrategy === 'warn') { %>
 		console.warn(err.message);
 		<% } else if(errorHandlingStrategy === 'throw') { %>
-		console.error(err.message);
 		throw err;
 		<% } %>
 	});

--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ var errorHandlingStrategies = ['lenient', 'warn', 'throw'];
 module.exports = function (src, options) {
 	options = options || {};
 	options.errorHandlingStrategy = errorHandlingStrategies.indexOf(options.errorHandlingStrategy) !== -1 && options.errorHandlingStrategy || errorHandlingStrategies[0];
-	options.useImageMagick = options.useImageMagick;
 
 	// Determine the type of the image provided
 	var mimetype = mime.lookup(src);

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ var errorHandlingStrategies = ['lenient', 'warn', 'throw'];
 module.exports = function (src, options) {
 	options = options || {};
 	options.errorHandlingStrategy = errorHandlingStrategies.indexOf(options.errorHandlingStrategy) !== -1 && options.errorHandlingStrategy || errorHandlingStrategies[0];
+	options.useImageMagick = options.useImageMagick;
 
 	// Determine the type of the image provided
 	var mimetype = mime.lookup(src);


### PR DESCRIPTION
Hi Sam, I've added an option to use ImageMagick instead of GraphicsMagick. In our environment it isn't possible to install GraphicsMagick from the default Linux repos (RHEL 6.6). Could you incorporate this change? I think adding an option instead of detection is better, because it's more explicit and it's easier to implement.
