### PR TITLE
mipmap support for newer android versions

### DIFF
--- a/platforms.json
+++ b/platforms.json
@@ -25,6 +25,10 @@
       {
         "file": "drawable-xxhdpi/icon.png",
         "dimension": 144
+      },
+      {
+        "file": "drawable-xxxhdpi/icon.png",
+        "dimension": 192
       }
     ]
   },

--- a/platforms.json
+++ b/platforms.json
@@ -3,34 +3,6 @@
     "root": "res",
     "icons": [
       {
-        "file": "drawable/icon.png",
-        "dimension": 96
-      },
-      {
-        "file": "drawable-ldpi/icon.png",
-        "dimension": 36
-      },
-      {
-        "file": "drawable-mdpi/icon.png",
-        "dimension": 48
-      },
-      {
-        "file": "drawable-hdpi/icon.png",
-        "dimension": 72
-      },
-      {
-        "file": "drawable-xhdpi/icon.png",
-        "dimension": 96
-      },
-      {
-        "file": "drawable-xxhdpi/icon.png",
-        "dimension": 144
-      },
-      {
-        "file": "drawable-xxxhdpi/icon.png",
-        "dimension": 192
-      },
-      {
         "file": "mipmap-ldpi/icon.png",
         "dimension": 36
       },

--- a/platforms.json
+++ b/platforms.json
@@ -29,6 +29,30 @@
       {
         "file": "drawable-xxxhdpi/icon.png",
         "dimension": 192
+      },
+      {
+        "file": "mipmap-ldpi/icon.png",
+        "dimension": 36
+      },
+      {
+        "file": "mipmap-mdpi/icon.png",
+        "dimension": 48
+      },
+      {
+        "file": "mipmap-hdpi/icon.png",
+        "dimension": 72
+      },
+      {
+        "file": "mipmap-xhdpi/icon.png",
+        "dimension": 96
+      },
+      {
+        "file": "mipmap-xxhdpi/icon.png",
+        "dimension": 144
+      },
+      {
+        "file": "mipmap-xxxhdpi/icon.png",
+        "dimension": 192
       }
     ]
   },


### PR DESCRIPTION
Newer versions use mipmap icons instead of drawable icons. At least with tools v25 my gulp-cordova tasks generate a cordova project with the following snippet in the AndroidManifest.xml:
```
<application android:hardwareAccelerated="true" android:icon="@mipmap/icon"
```

Hence the drawable icons generated by gulp-cordova-icon are not found. In this PR I also generate the mipmap icons. For backwards compatibility I also keep generating the drawable icons in case people use older SDK versions.

Also added the new xxxhdpi resolution icons